### PR TITLE
Remove unused vpc_id variable

### DIFF
--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,8 +1,3 @@
-variable "vpc_id" {
-  description = "VPC ID where the EC2 instance will be created"
-  type        = string
-}
-
 variable "subnet_ids" {
   description = "List of subnet IDs where the EC2 instance can be created"
   type        = list(string)


### PR DESCRIPTION
Removed the unused vpc_id variable from the EC2 module to fix tflint warning.